### PR TITLE
Release 2.0.1+jdk.21 maven central jira staging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,7 @@
 	<groupId>com.slytechs.jnet</groupId>
 	<artifactId>jnetpcap</artifactId>
 	<!-- mvn versions:set -DnewVersion=_new_version_ -->
-<!--	<version>2.0.1+jdk.21</version>-->
-	<version>2.0.1-SNAPSHOT</version>
+	<version>2.0.1+jdk.21</version>
 	<name>jNetPcap OS</name>
 	<description>A Java wrapper for native libpcap library</description>
 	<url>https://www.jnetpcap.org</url>
@@ -38,6 +37,14 @@
 		</developer>
 	</developers>
 	<dependencies>
+		<!--
+		https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-dependency-plugin -->
+		<dependency>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-dependency-plugin</artifactId>
+			<version>3.6.1</version>
+		</dependency>
+
 		<!--
 		https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-compiler-plugin -->
 		<dependency>
@@ -195,18 +202,18 @@
 		</plugins>
 	</build>
 	<distributionManagement>
-		
+
 		<snapshotRepository>
-			<id>ossrh-snapshots</id>
+			<id>ossrh</id>
 			<url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
 		</snapshotRepository>
-		
+
 		<repository>
 			<id>ossrh</id>
 			<url>
-				https://s01.oss.sonatype.org/service/local/staging/deploy/maven2</url>
+				https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
 		</repository>
-		
+
 		<!-- mvn clean site site:stage scm-publish:publish-scm -->
 		<site>
 			<id>github</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1,14 +1,17 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.slytechs.jnet</groupId>
 	<artifactId>jnetpcap</artifactId>
 	<!-- mvn versions:set -DnewVersion=_new_version_ -->
-	<version>2.0.0</version>
-	<name>jNetPcap</name>
+<!--	<version>2.0.1+jdk.21</version>-->
+	<version>2.0.1-SNAPSHOT</version>
+	<name>jNetPcap OS</name>
 	<description>A Java wrapper for native libpcap library</description>
 	<url>https://www.jnetpcap.org</url>
 	<properties>
-		<jdk.version>22</jdk.version>
+		<jdk.version>21</jdk.version>
 		<project.build.sourceEncoding>${java.encoding}</project.build.sourceEncoding>
 		<maven.compiler.source>${jdk.version}</maven.compiler.source>
 		<maven.compiler.target>${jdk.version}</maven.compiler.target>
@@ -17,6 +20,7 @@
 		<java.native>--enable-native-access=ALL-UNNAMED</java.native>
 		<groups>user-permission</groups>
 		<excludeGroups>windows-api|unix-api|linux-api</excludeGroups>
+		<sign-artifacts>gpg.passphrase</sign-artifacts>
 	</properties>
 	<licenses>
 		<license>
@@ -34,13 +38,15 @@
 		</developer>
 	</developers>
 	<dependencies>
-		<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-compiler-plugin -->
+		<!--
+		https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-compiler-plugin -->
 		<dependency>
 			<groupId>org.apache.maven.plugins</groupId>
 			<artifactId>maven-compiler-plugin</artifactId>
 			<version>3.11.0</version>
 		</dependency>
-		<!-- https://mvnrepository.com/artifact/org.junit.platform/junit-platform-suite-api -->
+		<!--
+		https://mvnrepository.com/artifact/org.junit.platform/junit-platform-suite-api -->
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-suite-api</artifactId>
@@ -99,7 +105,8 @@
 					<groups>${groups}</groups>
 					<excludedGroups>${excludeGroups}</excludedGroups>
 					<argLine>
-						${java.library.path.libpcap} ${java.preview} ${java.native}
+						${java.library.path.libpcap} ${java.preview}
+						${java.native}
 					</argLine>
 				</configuration>
 			</plugin>
@@ -109,16 +116,26 @@
 				<version>3.4.1 </version>
 				<configuration>
 					<doctitle>Public API for ${project.name} ${project.version}</doctitle>
-					<windowtitle>Public API for ${project.name} ${project.version}</windowtitle>
+					<windowtitle>Public API for ${project.name}
+						${project.version}</windowtitle>
 					<encoding>${java.encoding}</encoding>
 					<source>${jdk.version}</source>
 					<overview>${basedir}/Overview.html</overview>
 					<additionalOptions>
-								${java.preview}
+						${java.preview}
 					</additionalOptions>
 					<show>public</show>
-          			<excludePackageNames>*.internal</excludePackageNames>
+					<excludePackageNames>*.internal</excludePackageNames>
 				</configuration>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -128,8 +145,74 @@
 					<scmBranch>gh-pages</scmBranch>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>2.2.1</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.sonatype.plugins</groupId>
+				<artifactId>nexus-staging-maven-plugin</artifactId>
+				<version>1.6.13</version>
+				<extensions>true</extensions>
+				<configuration>
+					<serverId>ossrh</serverId>
+					<nexusUrl>https://s01.oss.sonatype.org</nexusUrl>
+					<autoReleaseAfterClose>true</autoReleaseAfterClose>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-gpg-plugin</artifactId>
+				<version>1.5</version>
+				<executions>
+					<execution>
+						<id>sign-artifacts</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>sign</goal>
+						</goals>
+						<configuration>
+							<passphraseServerId>${sign-artifacts}</passphraseServerId>
+							<gpgArguments>
+								<arg>--pinentry-mode</arg>
+								<arg>loopback</arg>
+							</gpgArguments>
+						</configuration>
+
+					</execution>
+				</executions>
+			</plugin>
+
 		</plugins>
 	</build>
+	<distributionManagement>
+		
+		<snapshotRepository>
+			<id>ossrh-snapshots</id>
+			<url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+		</snapshotRepository>
+		
+		<repository>
+			<id>ossrh</id>
+			<url>
+				https://s01.oss.sonatype.org/service/local/staging/deploy/maven2</url>
+		</repository>
+		
+		<!-- mvn clean site site:stage scm-publish:publish-scm -->
+		<site>
+			<id>github</id>
+			<url>scm:git:git@github.com:slytechs-repos/jnetpcap.git</url>
+		</site>
+	</distributionManagement>
 	<reporting>
 		<plugins>
 			<plugin>
@@ -148,16 +231,19 @@
 				<version>3.4.1</version>
 				<configuration>
 					<doctitle>Public API for ${project.name} ${project.version}</doctitle>
-					<windowtitle>Public API for ${project.name} ${project.version}</windowtitle>
-					<testDoctitle>Test API for ${project.name} ${project.version}</testDoctitle>
-					<testWindowtitle>Test API for ${project.name} ${project.version}</testWindowtitle>
+					<windowtitle>Public API for ${project.name}
+						${project.version}</windowtitle>
+					<testDoctitle>Test API for ${project.name}
+						${project.version}</testDoctitle>
+					<testWindowtitle>Test API for ${project.name}
+						${project.version}</testWindowtitle>
 					<encoding>${java.encoding}</encoding>
 					<source>${jdk.version}</source>
 					<overview>${basedir}/Overview.html</overview>
 					<additionalOptions>
-								${java.preview}
+						${java.preview}
 					</additionalOptions>
-          			<excludePackageNames>*.internal</excludePackageNames>
+					<excludePackageNames>*.internal</excludePackageNames>
 				</configuration>
 				<reportSets>
 					<reportSet>
@@ -203,7 +289,8 @@
 			</activation>
 			<build></build>
 			<properties>
-				<java.library.path.libpcap.osx>-Djava.library.path=/usr/local/Cellar/libpcap/${libpcap.version}/lib</java.library.path.libpcap.osx>
+				<java.library.path.libpcap.osx>
+					-Djava.library.path=/usr/local/Cellar/libpcap/${libpcap.version}/lib</java.library.path.libpcap.osx>
 				<java.library.path.libpcap>${java.library.path.libpcap.osx}</java.library.path.libpcap>
 				<excludeGroups>windows-api|linux-api</excludeGroups>
 			</properties>
@@ -220,7 +307,8 @@
 				</file>
 			</activation>
 			<properties>
-				<java.library.path.libpcap.osx>-Djava.library.path=/opt/local/lib</java.library.path.libpcap.osx>
+				<java.library.path.libpcap.osx>
+					-Djava.library.path=/opt/local/lib</java.library.path.libpcap.osx>
 				<java.library.path.libpcap>${java.library.path.libpcap.osx}</java.library.path.libpcap>
 				<excludeGroups>windows-api|linux-api</excludeGroups>
 			</properties>
@@ -234,7 +322,8 @@
 				</os>
 			</activation>
 			<properties>
-				<java.library.path.libpcap.linux>-Djava.library.path=/usr/lib/x86-linux-gnu</java.library.path.libpcap.linux>
+				<java.library.path.libpcap.linux>
+					-Djava.library.path=/usr/lib/x86-linux-gnu</java.library.path.libpcap.linux>
 				<java.library.path.libpcap>${java.library.path.libpcap.linux}</java.library.path.libpcap>
 				<excludeGroups>windows-api</excludeGroups>
 			</properties>
@@ -248,7 +337,8 @@
 				</os>
 			</activation>
 			<properties>
-				<java.library.path.libpcap.linux64>-Djava.library.path=/usr/lib/x86_64-linux-gnu</java.library.path.libpcap.linux64>
+				<java.library.path.libpcap.linux64>
+					-Djava.library.path=/usr/lib/x86_64-linux-gnu</java.library.path.libpcap.linux64>
 				<java.library.path.libpcap>${java.library.path.libpcap.linux64}</java.library.path.libpcap>
 				<excludeGroups>windows-api</excludeGroups>
 			</properties>
@@ -262,7 +352,8 @@
 				</os>
 			</activation>
 			<properties>
-				<java.library.path.libpcap.linux64>-Djava.library.path=/usr/lib/x86_64-linux-gnu</java.library.path.libpcap.linux64>
+				<java.library.path.libpcap.linux64>
+					-Djava.library.path=/usr/lib/x86_64-linux-gnu</java.library.path.libpcap.linux64>
 				<java.library.path.libpcap>${java.library.path.libpcap.linux64}</java.library.path.libpcap>
 				<excludeGroups>windows-api</excludeGroups>
 			</properties>
@@ -276,8 +367,10 @@
 				</os>
 			</activation>
 			<properties>
-				<java.library.path.libpcap.windows64>-Djava.library.path="C:\\Windows\\SysWOW64"</java.library.path.libpcap.windows64>
-				<java.library.path.libpcap>${java.library.path.libpcap.windows64}</java.library.path.libpcap>
+				<java.library.path.libpcap.windows64>
+					-Djava.library.path="C:\\Windows\\SysWOW64"</java.library.path.libpcap.windows64>
+				<java.library.path.libpcap>
+					${java.library.path.libpcap.windows64}</java.library.path.libpcap>
 				<excludeGroups>unix-api|linux-api</excludeGroups>
 			</properties>
 		</profile>
@@ -290,7 +383,8 @@
 				</os>
 			</activation>
 			<properties>
-				<java.library.path.libpcap.windows>-Djava.library.path="C:\\Windows\\Program Files"</java.library.path.libpcap.windows>
+				<java.library.path.libpcap.windows>-Djava.library.path="C:\\Windows\\Program
+					Files"</java.library.path.libpcap.windows>
 				<java.library.path.libpcap>${java.library.path.libpcap.windows}</java.library.path.libpcap>
 				<excludeGroups>unix-api|linux-api</excludeGroups>
 			</properties>
@@ -302,14 +396,8 @@
 	</issueManagement>
 	<scm>
 		<connection>scm:git:git://github.com/slytechs-repos/jnetpcap.git</connection>
-		<developerConnection>scm:git:ssh:git://github.com/slytechs-repos/jnetpcap.git</developerConnection>
+		<developerConnection>
+			scm:git:ssh:git://github.com/slytechs-repos/jnetpcap.git</developerConnection>
 		<url>https://github.com/slytechs-repos/jnetpcap</url>
 	</scm>
-	<distributionManagement>
-		<!-- mvn clean site site:stage scm-publish:publish-scm -->
-		<site>
-			<id>github</id>
-			<url>scm:git:git@github.com:slytechs-repos/jnetpcap.git</url>
-		</site>
-	</distributionManagement>
 </project>

--- a/src/main/java/org/jnetpcap/Messages.java
+++ b/src/main/java/org/jnetpcap/Messages.java
@@ -1,19 +1,19 @@
 /*
- * Sly Technologies Free License
+ * Apache License, Version 2.0
  * 
- * Copyright 2023 Sly Technologies Inc.
+ * Copyright 2013-2022 Sly Technologies Inc.
  *
- * Licensed under the Sly Technologies Free License (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  * 
- * http://www.slytechs.com/free-license-text
- * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *   
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.jnetpcap;
 
@@ -21,18 +21,31 @@ import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
 /**
+ * Error message resource bundle factory.
+ *
  * @author Sly Technologies Inc
  * @author repos@slytechs.com
- *
  */
 public class Messages {
+
+	/** The Constant BUNDLE_NAME. */
 	private static final String BUNDLE_NAME = Messages.class.getPackageName() + ".messages"; //$NON-NLS-1$
 
+	/** The Constant RESOURCE_BUNDLE. */
 	private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
 
+	/**
+	 * Instantiates a new messages.
+	 */
 	private Messages() {
 	}
 
+	/**
+	 * Gets the string.
+	 *
+	 * @param key the key
+	 * @return the string
+	 */
 	public static String getString(String key) {
 		try {
 			return RESOURCE_BUNDLE.getString(key);

--- a/src/main/java/org/jnetpcap/Pcap.java
+++ b/src/main/java/org/jnetpcap/Pcap.java
@@ -3606,7 +3606,13 @@ public abstract sealed class Pcap implements AutoCloseable permits Pcap0_4 {
 	}
 
 	/**
-	 * @return the pcapHeaderABI
+	 * Gets the pcap header ABI (Abstract Binary Interface). Pcap ABI is used to
+	 * interpret native structures such as pcap descriptor, correctly on any
+	 * specific hardware platform. The ABI abstracts how native integers and
+	 * primitive types are represented by CPU architecture on a specific platform.
+	 *
+	 * @return the ABI of the pcap header for this pcap handle on this CPU
+	 *         architecture
 	 */
 	public PcapHeaderABI getPcapHeaderABI() {
 		return pcapHeaderABI;

--- a/src/main/java/org/jnetpcap/PcapActivatedException.java
+++ b/src/main/java/org/jnetpcap/PcapActivatedException.java
@@ -1,19 +1,19 @@
 /*
- * Sly Technologies Free License
+ * Apache License, Version 2.0
  * 
- * Copyright 2023 Sly Technologies Inc.
+ * Copyright 2013-2022 Sly Technologies Inc.
  *
- * Licensed under the Sly Technologies Free License (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  * 
- * http://www.slytechs.com/free-license-text
- * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *   
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.jnetpcap;
 
@@ -26,18 +26,23 @@ package org.jnetpcap;
  */
 public class PcapActivatedException extends PcapException {
 
+	/** The Constant serialVersionUID. */
 	private static final long serialVersionUID = 5824725740629248762L;
 
 	/**
-	 * @param pcapErrorCode
+	 * Instantiates a new pcap activated exception.
+	 *
+	 * @param pcapErrorCode the pcap error code
 	 */
 	public PcapActivatedException(int pcapErrorCode) {
 		super(pcapErrorCode);
 	}
 
 	/**
-	 * @param pcapErrorCode
-	 * @param message
+	 * Instantiates a new pcap activated exception.
+	 *
+	 * @param pcapErrorCode the pcap error code
+	 * @param message       the message
 	 */
 	public PcapActivatedException(int pcapErrorCode, String message) {
 		super(pcapErrorCode, message);

--- a/src/main/java/org/jnetpcap/PcapErrorHandler.java
+++ b/src/main/java/org/jnetpcap/PcapErrorHandler.java
@@ -1,32 +1,41 @@
 /*
- * Sly Technologies Free License
+ * Apache License, Version 2.0
  * 
- * Copyright 2023 Sly Technologies Inc.
+ * Copyright 2013-2022 Sly Technologies Inc.
  *
- * Licensed under the Sly Technologies Free License (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  * 
- * http://www.slytechs.com/free-license-text
- * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *   
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.jnetpcap;
 
 /**
+ * Pcap error code and messages handler.
+ *
  * @author Sly Technologies Inc
  * @author repos@slytechs.com
- *
  */
 public class PcapErrorHandler {
+	
+	/**
+	 * Instantiates a new pcap error handler.
+	 */
+	public PcapErrorHandler() {
+	}
 
 	/**
-	 * @param string
-	 * @return
+	 * Gets the error string.
+	 *
+	 * @param key the key
+	 * @return the string
 	 */
 	public static String getString(String key) {
 		return key;

--- a/src/main/java/org/jnetpcap/PcapHeader.java
+++ b/src/main/java/org/jnetpcap/PcapHeader.java
@@ -42,7 +42,6 @@ import org.jnetpcap.internal.PcapHeaderABI;
  * 
  * @author Sly Technologies Inc
  * @author repos@slytechs.com
- * @author Mark Bednarczyk
  * @see LibraryPolicy#SYSTEM_PROPERTY_ABI
  */
 public final class PcapHeader {
@@ -389,7 +388,7 @@ public final class PcapHeader {
 	 *
 	 * @param abi           the abi
 	 * @param headerAddress the header address
-	 * @param arena       the session
+	 * @param arena         the session
 	 */
 	PcapHeader(PcapHeaderABI abi, MemorySegment headerAddress, Arena arena) {
 		this.abi = abi;
@@ -486,6 +485,14 @@ public final class PcapHeader {
 		return timestamp(isNanoTime);
 	}
 
+	/**
+	 * Timestamp in either nano or milli second precision.
+	 *
+	 * @param nanoTime if true, timestamp is returned with nano second precision,
+	 *                 otherwise millis is returned
+	 * @return the timestamp value as 64-bit long
+	 * @throws PcapHeaderException the pcap header exception
+	 */
 	public long timestamp(boolean nanoTime) throws PcapHeaderException {
 		if (nanoTime)
 			return tvSec() * NANO_TIME_SCALE + tvUsec();
@@ -499,7 +506,6 @@ public final class PcapHeader {
 	 * @return the long
 	 * @throws PcapHeaderException the pcap header exception
 	 */
-
 	public long toEpochMilli() throws PcapHeaderException {
 		return toEpochMilli(false);
 	}

--- a/src/main/java/org/jnetpcap/PcapHeaderException.java
+++ b/src/main/java/org/jnetpcap/PcapHeaderException.java
@@ -31,8 +31,6 @@ import org.jnetpcap.internal.PcapHeaderABI;
  * 
  * @author Sly Technologies Inc
  * @author repos@slytechs.com
- * @author Mark Bednarczyk
- *
  */
 public class PcapHeaderException extends RuntimeException {
 
@@ -42,6 +40,7 @@ public class PcapHeaderException extends RuntimeException {
 	 */
 	public static class OutOfRangeException extends PcapHeaderException {
 
+		/** The Constant serialVersionUID. */
 		private static final long serialVersionUID = -1194844250182172809L;
 
 		/**
@@ -53,11 +52,24 @@ public class PcapHeaderException extends RuntimeException {
 		 */
 		public static boolean INCLUDE_POSSIBILITIES = true;
 
+		/** The abi. */
 		private final PcapHeaderABI abi;
+		
+		/** The value. */
 		private final int value;
+		
+		/** The possible values. */
 		private List<String> possibleValues;
+		
+		/** The method name. */
 		private String methodName = "Possibilities";
 
+		/**
+		 * Instantiates a new out of range exception.
+		 *
+		 * @param abi   the abi
+		 * @param value the value
+		 */
 		public OutOfRangeException(PcapHeaderABI abi, int value) {
 			super("invalid length [%d] from PcapHeaderABI [%s]"
 					.formatted(value, abi.name()));
@@ -66,6 +78,8 @@ public class PcapHeaderException extends RuntimeException {
 		}
 
 		/**
+		 * Gets the possiblities.
+		 *
 		 * @return the possibleValues
 		 */
 		public List<String> getPossiblities() {
@@ -73,18 +87,28 @@ public class PcapHeaderException extends RuntimeException {
 		}
 
 		/**
+		 * Gets the value.
+		 *
 		 * @return the value
 		 */
 		public int getValue() {
 			return value;
 		}
 
+		/**
+		 * Sets the possibilities.
+		 *
+		 * @param possibleValues the new possibilities
+		 */
 		public void setPossibilities(List<String> possibleValues) {
 			this.possibleValues = possibleValues;
 		}
 
 		/**
+		 * Sets the possiblities.
+		 *
 		 * @param possibleValues the possibleValues to set
+		 * @return the out of range exception
 		 */
 		public OutOfRangeException setPossiblities(List<String> possibleValues) {
 			this.possibleValues = possibleValues;
@@ -93,6 +117,8 @@ public class PcapHeaderException extends RuntimeException {
 		}
 
 		/**
+		 * Gets the abi.
+		 *
 		 * @return the abi
 		 */
 		public String getAbi() {
@@ -100,6 +126,9 @@ public class PcapHeaderException extends RuntimeException {
 		}
 
 		/**
+		 * Gets the message.
+		 *
+		 * @return the message
 		 * @see java.lang.Throwable#getMessage()
 		 */
 		@Override
@@ -116,6 +145,8 @@ public class PcapHeaderException extends RuntimeException {
 		}
 
 		/**
+		 * Gets the method name.
+		 *
 		 * @return the methodName
 		 */
 		public String getMethodName() {
@@ -123,7 +154,10 @@ public class PcapHeaderException extends RuntimeException {
 		}
 
 		/**
+		 * Sets the method name.
+		 *
 		 * @param methodName the methodName to set
+		 * @return the out of range exception
 		 */
 		public OutOfRangeException setMethodName(String methodName) {
 			this.methodName = methodName;
@@ -132,17 +166,23 @@ public class PcapHeaderException extends RuntimeException {
 
 	}
 
+	/** The Constant serialVersionUID. */
 	private static final long serialVersionUID = -694519865697844153L;
 
 	/**
-	 * @param message
+	 * Instantiates a new pcap header exception.
+	 *
+	 * @param message the message
 	 */
 	public PcapHeaderException(String message) {
 		super(message);
 	}
 
 	/**
-	 * @param message
+	 * Instantiates a new pcap header exception.
+	 *
+	 * @param message the message
+	 * @param cause   the cause
 	 */
 	public PcapHeaderException(String message, Throwable cause) {
 		super(message, cause);

--- a/src/main/java/org/jnetpcap/PcapMessages.java
+++ b/src/main/java/org/jnetpcap/PcapMessages.java
@@ -27,13 +27,14 @@ import java.util.ResourceBundle;
  * 
  * @author Sly Technologies Inc
  * @author repos@slytechs.com
- * @author mark
- *
  */
 public class PcapMessages extends PropertyResourceBundle {
+	
 	/**
-	 * @param reader
-	 * @throws IOException
+	 * Instantiates a new pcap messages.
+	 *
+	 * @param reader the reader
+	 * @throws IOException Signals that an I/O exception has occurred.
 	 */
 	public PcapMessages(Reader reader) throws IOException {
 		super(reader);

--- a/src/main/java/org/jnetpcap/spi/PcapMessagesProvider.java
+++ b/src/main/java/org/jnetpcap/spi/PcapMessagesProvider.java
@@ -1,28 +1,29 @@
 /*
- * Sly Technologies Free License
+ * Apache License, Version 2.0
  * 
- * Copyright 2023 Sly Technologies Inc.
+ * Copyright 2013-2022 Sly Technologies Inc.
  *
- * Licensed under the Sly Technologies Free License (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  * 
- * http://www.slytechs.com/free-license-text
- * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *   
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.jnetpcap.spi;
 
 import java.util.spi.ResourceBundleProvider;
 
 /**
+ * The Interface PcapMessagesProvider.
+ *
  * @author Sly Technologies Inc
  * @author repos@slytechs.com
- *
  */
 public interface PcapMessagesProvider extends ResourceBundleProvider {
 

--- a/src/main/java/org/jnetpcap/util/PcapPacketRef.java
+++ b/src/main/java/org/jnetpcap/util/PcapPacketRef.java
@@ -29,9 +29,11 @@ import static java.lang.foreign.ValueLayout.*;
  * packet data. The scope of these addresses is libpcap packet scope and should
  * be used with great care or VM crashes can occur.
  *
+ * @param abi    platform specific ABI (Abstract Binary Interface)
+ * @param header raw pcap header in a memory segment
+ * @param data   raw packet data in a memory segment
  * @author Sly Technologies Inc
  * @author repos@slytechs.com
- * @author mark
  */
 public record PcapPacketRef(Object abi, MemorySegment header, MemorySegment data) {
 


### PR DESCRIPTION
Release updates pom.xml for deployment to Maven Central repository. 

This is a JDK 21 specific release, as **FFM preview-feature** requires  JDK version specific JRE binaries.
There are no API changes between 2.0.0 release and 2.0.1.